### PR TITLE
Create users-posts-comments for every test on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 1. `yarn cypress:run` to run the headless test suite.
 1. `yarn cypress:open` to open Cypress app and run tests manually or write new ones.
 
-Note: by default the tests are running against your local [development server](https://github.com/FreeFeed/freefeed-server), so it should be installed and running when your run the test suite. You can change the target server by modifying `"baseUrl"` and `"backendUrl"` in `./cypress.json` config file.
+Note: by default the tests are running against your local [development server](https://github.com/FreeFeed/freefeed-server), so it should be installed and running when your run the test suite. You can change the target server by modifying `"baseUrl"`, `"backendUrl"` and `"authTokenLocalStorageName"` in `./cypress.json` config file.
 
 ### Useful links
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 1. `yarn` to install Cypress (https://cypress.io).
 1. `yarn cypress:run` to run the headless test suite.
-1. `yarn cypress:open` to open Cypress app and run tests manually or write new ones. 
+1. `yarn cypress:open` to open Cypress app and run tests manually or write new ones.
 
-Note: by default the tests are running against your local [development server](https://github.com/FreeFeed/freefeed-server), so it should be installed and running when your run the test suite. You can change the target server by modifying `"baseUrl"` in `./cypress.json` config file (for example, by setting it to `"baseUrl": "https://candy.freefeed.net/"`), but signup tests won't pass because of captcha.
+Note: by default the tests are running against your local [development server](https://github.com/FreeFeed/freefeed-server), so it should be installed and running when your run the test suite. You can change the target server by modifying `"baseUrl"` and `"backendUrl"` in `./cypress.json` config file.
 
 ### Useful links
 
@@ -12,3 +12,4 @@ Note: by default the tests are running against your local [development server](h
 - https://docs.cypress.io/api/api/table-of-contents.html
 - https://docs.cypress.io/guides/references/configuration.html
 - https://docs.cypress.io/guides/guides/continuous-integration.html
+- https://docs.cypress.io/guides/references/best-practices.html

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:3333/",
+  "backendUrl": "http://localhost:3000",
   "integrationFolder": "cypress/tests",
   "defaultCommandTimeout": 5000,
   "video": false

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "http://localhost:3333/",
   "backendUrl": "http://localhost:3000",
+  "authTokenLocalStorageName": "freefeed_authToken",
   "integrationFolder": "cypress/tests",
   "defaultCommandTimeout": 5000,
   "video": false

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,6 +29,22 @@ import 'cypress-localstorage-commands';
 import 'cypress-file-upload';
 
 const backendUrl = Cypress.config('backendUrl');
+const authTokenLocalStorageName = Cypress.config('authTokenLocalStorageName');
+
+// Login as a user
+Cypress.Commands.add('login', ({ username, password }) => {
+  cy.request({
+    method: 'POST',
+    url: `${backendUrl}/v1/session`,
+    body: {
+      username,
+      password,
+    },
+  }).then((response) => {
+    const authToken = response.body.authToken;
+    window.localStorage.setItem(authTokenLocalStorageName, authToken);
+  });
+});
 
 // Create a new user and log in
 Cypress.Commands.add('register', ({ username, password, email, screenName }) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,3 +27,71 @@
 import '@testing-library/cypress/add-commands';
 import 'cypress-localstorage-commands';
 import 'cypress-file-upload';
+
+const backendUrl = Cypress.config('backendUrl');
+
+// Create a new user and log in
+Cypress.Commands.add('register', ({ username, password, email, screenName }) => {
+  cy.request({
+    method: 'POST',
+    url: `${backendUrl}/v1/users`,
+    body: {
+      username,
+      screenName,
+      email,
+      password,
+    },
+  }).then((response) => response.body);
+});
+
+// Change privacy of current user (must be already logged in)
+Cypress.Commands.add('changeUserPrivacy', (userId, targetPrivacy, authToken) => {
+  const isPrivate = targetPrivacy === 'private' ? '1' : '0';
+  const isProtected = targetPrivacy === 'protected' ? '1' : '0';
+
+  const body = {
+    user: { isPrivate, isProtected },
+  };
+
+  cy.request({
+    method: 'PUT',
+    url: `${backendUrl}/v1/users/${userId}`,
+    body,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  }).then((response) => response.body);
+});
+
+// Write a simple post to user's own feed or some other feeds (must be already logged in)
+Cypress.Commands.add('post', (postText, feeds, authToken) => {
+  const body = {
+    post: { body: postText, attachments: [] },
+    meta: { feeds, commentsDisabled: false },
+  };
+
+  cy.request({
+    method: 'POST',
+    url: `${backendUrl}/v1/posts`,
+    body,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  }).then((response) => response.body);
+});
+
+// Write a comment to a post (must be already logged in)
+Cypress.Commands.add('comment', (commentText, postId, authToken) => {
+  const body = {
+    comment: { body: commentText, postId },
+  };
+
+  cy.request({
+    method: 'POST',
+    url: `${backendUrl}/v1/comments`,
+    body,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  }).then((response) => response.body);
+});

--- a/cypress/tests/clikes/clikes.js
+++ b/cypress/tests/clikes/clikes.js
@@ -1,0 +1,42 @@
+const randomUser = require('../../utils/random-user');
+
+describe('Users can like comments', () => {
+  it('Can like public comments in public posts', () => {
+    // 1. user A creates a post with a comment
+    // 2. user B likes this comment
+    // 3. user B sees +1 comment like
+    // 4. user A cannot like their own comment
+
+    const userA = randomUser();
+    const userB = randomUser();
+
+    cy.register(userA).then((userAData) => {
+      const authTokenA = userAData.authToken;
+
+      cy.register(userB).then((userBData) => {
+        const authTokenB = userBData.authToken;
+
+        cy.post('Public post with comments to be liked', [userA.username], authTokenA).then((post) => {
+          const postId = post.posts.id;
+
+          cy.comment('Please like me I am awesome', postId, authTokenA).then(() => {
+            cy.login(userB).then(() => {
+              cy.visit(`/${userA.username}/${postId}`);
+              cy.findByRole('article').should('exist');
+              cy.get('[role=main]').findAllByRole('comment').eq(0).findByLabelText('Like this comment').click();
+              cy.get('[role=main]').findAllByRole('comment').eq(0).findByLabelText('1 comment like').should('exist');
+            });
+
+            cy.login(userA).then(() => {
+              cy.visit(`/${userA.username}/${postId}`);
+              cy.findByRole('article').should('exist');
+              cy.get('[role=main]').findAllByRole('comment').eq(0).findByLabelText('1 comment like').should('exist');
+              cy.get('[role=main]').findAllByRole('comment').eq(0).findByLabelText('Like this comment').click();
+              cy.get('[role=main]').findAllByRole('comment').eq(0).findByLabelText('1 comment like').should('exist');
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/cypress/utils/random-user.js
+++ b/cypress/utils/random-user.js
@@ -5,17 +5,17 @@ function getRandomInRange(min, max) {
 function randomUser() {
   const max = getRandomInRange(7, 15);
   const num = getRandomInRange(1, max);
-  const unimatrix = getRandomInRange(1000, 99999);
+  const unimatrix = getRandomInRange(10000, 99999);
 
-  const id = Date.now();
+  const username = `borg${Date.now()}${getRandomInRange(100000000, 999999999)}`.slice(0, 25);
 
   return {
-    username: `borg${id}`,
+    username,
     screenName: `${num} of ${max}, unimatrix ${unimatrix}`,
     description:
       'We are the Borg. Lower your shields and surrender your ships. We will add your biological and technological distinctiveness to our own. Your culture will adapt to service us. Resistance is futile.',
     password: `${Math.random().toString(36)}${Math.random().toString(36)}`,
-    email: `borg${id}@freefeed.net`,
+    email: `${username}@freefeed.net`,
   };
 }
 


### PR DESCRIPTION
This PR rewrites some of the tests to follow Cypress [best practices](https://docs.cypress.io/guides/references/best-practices.html#Organizing-Tests-Logging-In-Controlling-State), specifically regarding registrations, logins, and reusing application state between tests.

With this new approach, every test starts with creation of new users, new posts, and new comments as required, through API. This ensures that the test suite can run on any server (candy, prod, local dev with empty DB, whatever) and that each test is as independent as it is possible. On the other hand, this approach makes tests more verbose and increases load on the backend (which might be undersirable in the long term). I plan to continue learning more about how to write tests with Cypress and will come back to this if and when I have a better solution.
